### PR TITLE
Improve Duplicate Issue Search in Team Response Phase (#894)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "karma-spec-reporter": "0.0.32",
     "moment": "^2.24.0",
     "ngx-markdown": "^8.2.1",
+    "ngx-mat-select-search": "^1.8.0",
     "node-fetch": "^2.6.0",
     "rxjs": "6.5.3",
     "tslib": "^1.9.0",

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.html
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.html
@@ -19,18 +19,26 @@
 
   <mat-select
     [style.display]="isEditing ? 'block' : 'none'"
+    style="width: 100%"
     class="no-arrow"
     placeholder="-"
     [value]="issue.duplicateOf"
     (selectionChange)="updateDuplicateStatus($event)"
     (openedChange)="handleSelectionOpenChange($event)"
   >
+    <mat-option>
+      <ngx-mat-select-search
+        placeholderLabel="Search issues"
+        noEntriesFoundLabel="No issues found"
+        [formControl]="searchFilterCtrl"
+      ></ngx-mat-select-search>
+    </mat-option>
     <mat-select-trigger></mat-select-trigger>
     <mat-option
       [matTooltip]="issue.title"
       [matTooltipDisabled]="!isTooltipNecessary(issue)"
       [matTooltipPosition]="'left'"
-      *ngFor="let issue of duplicatedIssueList | async"
+      *ngFor="let issue of filteredDuplicateIssueList | async"
       [disabled]="dupIssueOptionIsDisabled(issue)"
       [value]="issue.id"
     >

--- a/src/app/shared/issue/issue-components.module.ts
+++ b/src/app/shared/issue/issue-components.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { MatProgressBarModule } from '@angular/material';
 import { MarkdownModule } from 'ngx-markdown';
+import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { CommentEditorModule } from '../comment-editor/comment-editor.module';
 import { SharedModule } from '../shared.module';
 import { AssigneeComponent } from './assignee/assignee.component';
@@ -13,7 +14,7 @@ import { TitleComponent } from './title/title.component';
 import { UnsureCheckboxComponent } from './unsure-checkbox/unsure-checkbox.component';
 
 @NgModule({
-  imports: [SharedModule, CommentEditorModule, MatProgressBarModule, MarkdownModule.forChild()],
+  imports: [SharedModule, CommentEditorModule, MatProgressBarModule, NgxMatSelectSearchModule, MarkdownModule.forChild()],
   declarations: [
     TitleComponent,
     DescriptionComponent,

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -17,7 +17,18 @@
 
           <mat-form-field [style.visibility]="!duplicated.value ? 'hidden' : 'visible'" style="display: inline-block; width: 50%">
             <mat-select formControlName="duplicateOf" placeholder="Duplicate of">
-              <mat-option *ngFor="let issue of duplicatedIssueList | async" [disabled]="dupIssueOptionIsDisabled(issue)" [value]="issue.id">
+              <mat-option>
+                <ngx-mat-select-search
+                  placeholderLabel="Search issues"
+                  noEntriesFoundLabel="No issues found"
+                  [formControl]="searchFilterCtrl"
+                ></ngx-mat-select-search>
+              </mat-option>
+              <mat-option
+                *ngFor="let issue of filteredDuplicateIssueList | async"
+                [disabled]="dupIssueOptionIsDisabled(issue)"
+                [value]="issue.id"
+              >
                 <span class="mat-body-strong"> #{{ issue.id }}: </span> <span class="mat-body">{{ issue.title }}</span>
                 <span *ngIf="dupIssueOptionIsDisabled(issue)" class="mat-caption" style="color: #f44336">
                   ({{ getDisabledDupOptionErrorText(issue) }})

--- a/src/app/shared/view-issue/new-team-response/new-team-response.module.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MarkdownModule } from 'ngx-markdown';
+import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { CommentEditorModule } from '../../comment-editor/comment-editor.module';
 import { IssueComponentsModule } from '../../issue/issue-components.module';
 import { LabelDropdownModule } from '../../label-dropdown/label-dropdown.module';
@@ -11,7 +12,15 @@ import { NewTeamResponseComponent } from './new-team-response.component';
 @NgModule({
   exports: [NewTeamResponseComponent, ConflictDialogComponent],
   declarations: [NewTeamResponseComponent, ConflictDialogComponent],
-  imports: [CommonModule, CommentEditorModule, SharedModule, IssueComponentsModule, LabelDropdownModule, MarkdownModule.forChild()],
+  imports: [
+    CommonModule,
+    CommentEditorModule,
+    SharedModule,
+    IssueComponentsModule,
+    LabelDropdownModule,
+    MarkdownModule.forChild(),
+    NgxMatSelectSearchModule
+  ],
   entryComponents: [ConflictDialogComponent]
 })
 export class NewTeamResponseModule {}


### PR DESCRIPTION
Choosing an issue as the parent of a duplicate issue can be
challenging. Users can receive close to a hundred issues in
the Team Response Phase so they would need to scroll
through everything to find the correct issue.

Let's add a search bar in the selection dropdown menu for
users to search for the parent issue by name or ID. Also, let's
include the ID of the parent duplicate issue for issues that
has already been duplicated, to ease the finding of the parent
issue.